### PR TITLE
fix emscripten compile

### DIFF
--- a/cloudini_lib/include/cloudini_lib/contrib/nanocdr.hpp
+++ b/cloudini_lib/include/cloudini_lib/contrib/nanocdr.hpp
@@ -36,8 +36,6 @@ enum class EncodingFlag : uint8_t { PLAIN_CDR = 0x0, PL_CDR = 0x2, PLAIN_CDR2 = 
 
 enum class Endianness : uint8_t { CDR_BIG_ENDIAN = 0x00, CDR_LITTLE_ENDIAN = 0x01 };
 
-constexpr Endianness getCurrentEndianness();
-
 template <typename T>
 inline void swapEndianness(T& val);
 
@@ -223,7 +221,7 @@ constexpr bool is_type_defined_v() {
   return is_type_defined<T>::value;
 }
 
-constexpr Endianness getCurrentEndianness() {
+inline Endianness getCurrentEndianness() {
   union {
     uint8_t u8;
     uint16_t u16 = 0x0100;


### PR DESCRIPTION
For some reason, emscripten doesn't recognize this as a valid constexpr function, and comes up with multiple definitions without it being inlined.

```
In file included from $PATH_TO/cloudini/cloudini_lib/ros_msg_utils.hpp:4:
$PATH_TO/cloudini/cloudini_lib/include/cloudini_lib/contrib/nanocdr.hpp:224:29: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
  224 | inline constexpr Endianness getCurrentEndianness() {
      |                             ^~~~~~~~~~~~~~~~~~~~
$PATH_TO/cloudini/cloudini_lib/include/cloudini_lib/contrib/nanocdr.hpp:230:10: note: read of member 'u8' of union with active member 'u16' is not allowed in a constant expression
  230 |   return endian_test.u8 == 0x01 ? Endianness::CDR_BIG_ENDIAN : Endianness::CDR_LITTLE_ENDIAN;
```

To build with emscripten:

```
cd ./cloudini_lib
mkdir build-wasm
cd build-wasm
source $PATH_TO/emsdk/emsdk_env.sh
emcmake cmake ..
cmake --build .
emcc libcloudini_lib.a -o cloudini.js
```