### PR TITLE
Fix compilation on arm

### DIFF
--- a/cloudini_lib/CMakeLists.txt
+++ b/cloudini_lib/CMakeLists.txt
@@ -107,10 +107,12 @@ target_link_libraries(cloudini_lib
 )
 
 if(NOT EMSCRIPTEN)
-  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_compile_options(cloudini_lib PRIVATE -msse4.1)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|i686")  
+    if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      target_compile_options(cloudini_lib PRIVATE -msse4.1)
+    endif()
   endif()
-
+  
   if(CLOUDINI_BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
   endif()


### PR DESCRIPTION
Hi and thanks for this amazing tool, another in the list of things everyone needs but noone implements. :clap: 

I have learnt that the simd msse compilation flags are not valid on arm architecture. It seems that they use NEOM, enabled by default. 