### PR TITLE
Null character termination

### DIFF
--- a/cloudini_lib/include/cloudini_lib/contrib/nanocdr.hpp
+++ b/cloudini_lib/include/cloudini_lib/contrib/nanocdr.hpp
@@ -18,7 +18,6 @@
 #include <array>
 #include <cstddef>
 #include <cstring>
-#include <iostream>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
I had a strange behavior when using foxglove for visualizing the point clouds that were decoded after a first encoding. It turns out that there is no additional null character termination when decoding the string fields. This make foxglove interpret the string data up to the character -1. 

So fields like "x", "rgb" or "my_frame" would become "", "rg", "my_fram". I was looking into CDR specification and so far I could not find an explicit reference that strings should be null terminated. I am left with this fix which is either fixing cloudini or foxglove :sweat_smile:   