### PR TITLE
Fix symbol lookup error

### DIFF
--- a/cloudini_ros/CMakeLists.txt
+++ b/cloudini_ros/CMakeLists.txt
@@ -97,6 +97,7 @@ set(PLUGIN_NAME cloudini_point_cloud_transport)
 
 add_library(${PLUGIN_NAME}
   SHARED
+  src/conversion_utils.cpp
   src/cloudini_publisher.cpp
   src/cloudini_subscriber.cpp
   src/plugin_manifest.cpp


### PR DESCRIPTION
Hi! Just wanted to share a small fix when using the `point_cloud_transport` package with the cloudini plugin.
Without the fix, there is the following symbol lookup error (on a fresh ROS 2 jazzy as well as humble installation). 

Steps to reproduce:
```
- ros2 run point_cloud_transport republish --ros-args -p in_transport:=raw -p out_transport:=cloudini --remap in:=/livox/lidar
- Publish some pointcloud data on /livox/lidar
```
Results in:
```
[INFO] [1752492701.434141613] [point_cloud_republisher]: The 'in_transport' parameter is set to: raw
[INFO] [1752492701.434236166] [point_cloud_republisher]: The 'out_transport' parameter is set to: cloudini
[INFO] [1752492701.435962085] [point_cloud_republisher]: Loading point_cloud_transport/cloudini_pub publisher
[INFO] [1752492701.439845465] [point_cloud_republisher]: out topic2: /out/cloudini
[INFO] [1752492701.439900054] [point_cloud_republisher]: Loading /in subscriber
[INFO] [1752492701.440847264] [point_cloud_republisher]: Subscribing to: /livox/lidar
[INFO] [1752492701.440873410] [point_cloud_republisher]: in topic: /livox/lidar
/opt/ros/jazzy/lib/point_cloud_transport/republish: symbol lookup error: /workspaces/ros2_workspace/install/cloudini_ros/lib/libcloudini_point_cloud_transport.so: undefined symbol: _ZN8Cloudini21ConvertToEncodingInfoERKN11sensor_msgs3msg12PointCloud2_ISaIvEEEf
[ros2run]: Process exited with failure 127
```

P.S.: Awesome library, thank you for sharing it!
