### PR TITLE
Remove 'lz4' compression method support

### DIFF
--- a/cloudini_lib/tools/src/cloudini_rosbag_converter.cpp
+++ b/cloudini_lib/tools/src/cloudini_rosbag_converter.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
       ("c,compress", "Convert PointCloud2 to CompressedPointCloud2")  //
       ("d,decode", "Convert CompressedPointCloud2 to PointCloud2")    //
       ("s,stats", "Print compression statistics")                     //
-      ("m,method", "Compression method to use when writing data back to mcap ('lz4' or 'zstd', 'none')",
+      ("m,method", "Compression method to use when writing data back to mcap ('zstd', 'none')",
        cxxopts::value<std::string>()->default_value("zstd"));
 
   auto parse_result = options.parse(argc, argv);
@@ -124,13 +124,13 @@ int main(int argc, char** argv) {
   // clang-format off
   const auto compression_options_map = std::unordered_map<std::string, Cloudini::CompressionOption>{
       {"none", Cloudini::CompressionOption::NONE},
-      {"lz4", Cloudini::CompressionOption::LZ4},
       {"zstd", Cloudini::CompressionOption::ZSTD}};
   // clang-format on
 
   std::string compression_method = parse_result["method"].as<std::string>();
   if (!compression_options_map.contains(compression_method)) {
     std::cerr << "Error: Invalid compression method: " << compression_method << std::endl;
+    std::cerr << "The application only supports 'zstd' and 'none'" << std::endl;
     return 1;
   }
   mcap_writer_compression = compression_options_map.at(compression_method);


### PR DESCRIPTION
Removed 'lz4' from the list of supported compression methods and updated related error messages.