### PR TITLE
fix resolution profile not applied in ros_topic_converter

### DIFF
--- a/cloudini_ros/src/topic_converter.cpp
+++ b/cloudini_ros/src/topic_converter.cpp
@@ -165,8 +165,8 @@ void CloudiniPointcloudConverter::callback(std::shared_ptr<rclcpp::SerializedMes
   auto pc_info = cloudini_ros::getDeserializedPointCloudMessage(raw_dds_msg);
 
   if (compressing_) {
-    const auto encoding_info = cloudini_ros::toEncodingInfo(pc_info);
     cloudini_ros::applyResolutionProfile(cloudini_ros::ResolutionProfile{}, pc_info.fields, resolution_);
+    const auto encoding_info = cloudini_ros::toEncodingInfo(pc_info);
     cloudini_ros::convertPointCloud2ToCompressedCloud(pc_info, encoding_info, output_raw_message_);
   } else {
     cloudini_ros::convertCompressedCloudToPointCloud2(pc_info, output_raw_message_);


### PR DESCRIPTION
When using `ros_topic_converter` with a non-zero resolution, the resolution
parameter had no effect on the compressed output. This happened because
`encoding_info` was computed before `applyResolutionProfile()` modified
`pc_info.fields`, so the compression remained effectively reversible even
when a non-zero resolution was specified.

This PR applies the resolution profile before computing `encoding_info`,
so `encoding_info` reflects the updated field resolutions.

### Changes

Before:

```cpp
const auto encoding_info = cloudini_ros::toEncodingInfo(pc_info);
cloudini_ros::applyResolutionProfile(cloudini_ros::ResolutionProfile{}, pc_info.fields, resolution_);
cloudini_ros::convertPointCloud2ToCompressedCloud(pc_info, encoding_info, output_raw_message_);
````

After:

```cpp
cloudini_ros::applyResolutionProfile(cloudini_ros::ResolutionProfile{}, pc_info.fields, resolution_);
const auto encoding_info = cloudini_ros::toEncodingInfo(pc_info);
cloudini_ros::convertPointCloud2ToCompressedCloud(pc_info, encoding_info, output_raw_message_);
```

### Testing

* ROS2 Humble
* Input data: KITTI dataset converted to rosbag2
* Tested `resolution = 0.001` (default) and `resolution = 0.01`

Before this patch:

* resolution parameter had no visible effect
* output remained reversible

After this patch:

* resolution affects compression as expected
* output is no longer reversible for non-zero resolution, as intended
