### PR TITLE
feat(gorilla): Gorilla bit-packed XOR for FLOAT64 lossless (backward compatible)

### DIFF
--- a/cloudini_lib/benchmarks/pcd_benchmark.cpp
+++ b/cloudini_lib/benchmarks/pcd_benchmark.cpp
@@ -121,6 +121,44 @@ static void PCD_Encode_Lossles_LZ4(benchmark::State& state) {
   PCD_Encode_Impl(state, cloud, info);
 }
 
+static void PCD_Decode_Lossles_ZST(benchmark::State& state) {
+  const auto cloud = loadCloud();
+  auto info = defaultEncodingInfo(cloud);
+  info.encoding_opt = Cloudini::EncodingOptions::LOSSLESS;
+  info.compression_opt = Cloudini::CompressionOption::ZSTD;
+  PCD_Decode_Impl(state, cloud, info);
+}
+
+static void PCD_Decode_Lossles_LZ4(benchmark::State& state) {
+  const auto cloud = loadCloud();
+  auto info = defaultEncodingInfo(cloud);
+  info.encoding_opt = Cloudini::EncodingOptions::LOSSLESS;
+  info.compression_opt = Cloudini::CompressionOption::LZ4;
+  PCD_Decode_Impl(state, cloud, info);
+}
+
+// v3 XOR baseline: force info.version = 3 so the encoder picks FieldEncoderFloat_XOR
+// (raw 4 bytes per float) instead of the v4 Gorilla bit-packed variant. Not a full
+// round-trip (the header's magic still advertises v4), just a stage-1+2 compression
+// measurement for comparison.
+static void PCD_Encode_LosslesXOR_v3_ZST(benchmark::State& state) {
+  const auto cloud = loadCloud();
+  auto info = defaultEncodingInfo(cloud);
+  info.encoding_opt = Cloudini::EncodingOptions::LOSSLESS;
+  info.compression_opt = Cloudini::CompressionOption::ZSTD;
+  info.version = 3;
+  PCD_Encode_Impl(state, cloud, info);
+}
+
+static void PCD_Encode_LosslesXOR_v3_LZ4(benchmark::State& state) {
+  const auto cloud = loadCloud();
+  auto info = defaultEncodingInfo(cloud);
+  info.encoding_opt = Cloudini::EncodingOptions::LOSSLESS;
+  info.compression_opt = Cloudini::CompressionOption::LZ4;
+  info.version = 3;
+  PCD_Encode_Impl(state, cloud, info);
+}
+
 //------------------------------------------------------------------------------------------
 static void PCD_Encode_Lossy_LZ4(benchmark::State& state) {
   const auto cloud = loadCloud();
@@ -219,6 +257,10 @@ static void PCD_Encode_Draco(benchmark::State& state) {
 
 BENCHMARK(PCD_Encode_Lossy_ZST);
 BENCHMARK(PCD_Encode_Lossy_LZ4);
+BENCHMARK(PCD_Encode_Lossles_ZST);
+BENCHMARK(PCD_Encode_Lossles_LZ4);
+BENCHMARK(PCD_Encode_LosslesXOR_v3_ZST);
+BENCHMARK(PCD_Encode_LosslesXOR_v3_LZ4);
 BENCHMARK(PCD_Encode_ZSTD_only);
 BENCHMARK(PCD_Encode_LZ4_only);
 
@@ -228,6 +270,8 @@ BENCHMARK(PCD_Encode_Draco);
 
 BENCHMARK(PCD_Decode_Lossy_ZST);
 BENCHMARK(PCD_Decode_Lossy_LZ4);
+BENCHMARK(PCD_Decode_Lossles_ZST);
+BENCHMARK(PCD_Decode_Lossles_LZ4);
 BENCHMARK(PCD_Decode_ZSTD_only);
 BENCHMARK(PCD_Decode_LZ4_only);
 

--- a/cloudini_lib/include/cloudini_lib/cloudini.hpp
+++ b/cloudini_lib/include/cloudini_lib/cloudini.hpp
@@ -60,7 +60,7 @@ EncodingOptions EncodingOptionsFromString(std::string_view str);
 CompressionOption CompressionOptionFromString(std::string_view str);
 FieldType FieldTypeFromString(std::string_view str);
 
-constexpr const uint8_t kEncodingVersion = 3;
+constexpr const uint8_t kEncodingVersion = 4;
 
 struct EncodingInfo {
   // Fields in the point cloud
@@ -234,7 +234,8 @@ class PointcloudDecoder {
  private:
   void updateDecoders(const EncodingInfo& info);
 
-  void decodeChunk(const EncodingInfo& info, ConstBufferView compressed_data, BufferView& output);
+  void decodeChunk(
+      const EncodingInfo& info, ConstBufferView compressed_data, BufferView& output, size_t expected_points);
 
   std::vector<std::unique_ptr<FieldDecoder>> decoders_;
   std::vector<uint8_t> decompressed_buffer_;

--- a/cloudini_lib/include/cloudini_lib/field_decoder.hpp
+++ b/cloudini_lib/include/cloudini_lib/field_decoder.hpp
@@ -152,6 +152,154 @@ class FieldDecoderFloat_XOR : public FieldDecoder {
 };
 
 //------------------------------------------------------------------------------------------
+// Gorilla/Chimp-style bit-packed XOR decoder. Mirrors FieldEncoderFloat_Gorilla.
+// Reads bits LSB-first within each byte; bytes are pulled from `input` on demand.
+template <typename FloatType>
+class FieldDecoderFloat_Gorilla : public FieldDecoder {
+ public:
+  FieldDecoderFloat_Gorilla(size_t field_offset) : offset_(field_offset) {
+    static_assert(std::is_floating_point<FloatType>::value, "FieldDecoderFloat_Gorilla requires a floating point type");
+    // Bit-packed: bytes are consumed nondeterministically across calls, so the per-point
+    // minInputBytes() check cannot be meaningful. Returning 0 disables that check for this
+    // field; getBits() throws on actual truncation.
+    min_input_bytes_ = 0;
+  }
+
+  void decode(ConstBufferView& input, BufferView dest_point_view) override;
+
+  void reset() override {
+    prev_bits_ = 0;
+    prev_leading_ = kLeadingSentinel;
+    prev_trailing_ = 0;
+    bit_buf_ = 0;
+    bit_count_ = 0;
+    first_ = true;
+  }
+
+ private:
+  using IntType = std::conditional_t<std::is_same<FloatType, float>::value, uint32_t, uint64_t>;
+  static constexpr size_t kTypeBits = sizeof(IntType) * 8;
+  static constexpr uint8_t kLeadingSentinel = 255;
+
+  inline uint64_t getBits(uint8_t nbits, ConstBufferView& input);
+
+  size_t offset_;
+  IntType prev_bits_ = 0;
+  uint8_t prev_leading_ = kLeadingSentinel;
+  uint8_t prev_trailing_ = 0;
+
+  uint64_t bit_buf_ = 0;
+  uint8_t bit_count_ = 0;
+  bool first_ = true;
+};
+
+template <typename FloatType>
+inline uint64_t FieldDecoderFloat_Gorilla<FloatType>::getBits(uint8_t nbits, ConstBufferView& input) {
+  // Split into two halves to avoid shifting a full byte into a near-full bit buffer
+  // (which would drop high-order bits). When we'd refill with a byte but bit_count_ > 56,
+  // we must first extract bits already in the buffer.
+  auto fillOne = [&]() {
+    if (input.size() == 0) {
+      throw std::runtime_error("FieldDecoderFloat_Gorilla: truncated input");
+    }
+    const uint64_t byte = static_cast<uint64_t>(input.data()[0]);
+    input.trim_front(1);
+    bit_buf_ |= (byte << bit_count_);
+    bit_count_ += 8;
+  };
+
+  // If we'd need more than 56 bits combined (bit_count_ + future fill) and nbits is large,
+  // process in two phases: first consume what's in the buffer, then refill.
+  if (nbits > 56 || bit_count_ > 56) {
+    // Phase 1: extract up to min(nbits, bit_count_) from current bit_buf_ without adding more.
+    const uint8_t phase1_bits = std::min<uint8_t>(nbits, bit_count_);
+    const uint64_t mask1 = (phase1_bits < 64) ? ((uint64_t{1} << phase1_bits) - 1) : ~uint64_t{0};
+    const uint64_t low = bit_buf_ & mask1;
+    if (phase1_bits < 64) {
+      bit_buf_ >>= phase1_bits;
+    } else {
+      bit_buf_ = 0;
+    }
+    bit_count_ -= phase1_bits;
+
+    const uint8_t remaining = nbits - phase1_bits;
+    if (remaining == 0) {
+      return low;
+    }
+    // Now bit_count_ is small; safe to refill.
+    while (bit_count_ < remaining) {
+      fillOne();
+    }
+    const uint64_t mask2 = (remaining < 64) ? ((uint64_t{1} << remaining) - 1) : ~uint64_t{0};
+    const uint64_t high = bit_buf_ & mask2;
+    if (remaining < 64) {
+      bit_buf_ >>= remaining;
+    } else {
+      bit_buf_ = 0;
+    }
+    bit_count_ -= remaining;
+    return low | (high << phase1_bits);
+  }
+
+  // Fast path: small nbits and small bit_count_ — can't overflow even if we add 8 more.
+  while (bit_count_ < nbits) {
+    fillOne();
+  }
+  const uint64_t mask = (nbits < 64) ? ((uint64_t{1} << nbits) - 1) : ~uint64_t{0};
+  const uint64_t result = bit_buf_ & mask;
+  bit_buf_ >>= nbits;
+  bit_count_ -= nbits;
+  return result;
+}
+
+template <typename FloatType>
+inline void FieldDecoderFloat_Gorilla<FloatType>::decode(ConstBufferView& input, BufferView dest_point_view) {
+  IntType value_bits;
+
+  if (first_) {
+    first_ = false;
+    const uint64_t raw = getBits(static_cast<uint8_t>(kTypeBits), input);
+    value_bits = static_cast<IntType>(raw);
+    prev_bits_ = value_bits;
+  } else {
+    const uint64_t flag = getBits(1, input);
+    if (flag == 0) {
+      // Same value as previous.
+      value_bits = prev_bits_;
+    } else {
+      const uint64_t control = getBits(1, input);
+      IntType xor_val;
+      if (control == 0) {
+        // Reuse previous window.
+        const uint8_t meaningful = static_cast<uint8_t>(kTypeBits - prev_leading_ - prev_trailing_);
+        const uint64_t bits = getBits(meaningful, input);
+        xor_val = static_cast<IntType>(bits << prev_trailing_);
+      } else {
+        // New window: read leading(5), meaningful-1(6), meaningful bits.
+        const uint8_t stored_leading = static_cast<uint8_t>(getBits(5, input));
+        const uint8_t meaningful = static_cast<uint8_t>(getBits(6, input) + 1);
+        const uint64_t bits = getBits(meaningful, input);
+        const uint8_t trailing = static_cast<uint8_t>(kTypeBits - stored_leading - meaningful);
+        xor_val = static_cast<IntType>(bits << trailing);
+        prev_leading_ = stored_leading;
+        prev_trailing_ = trailing;
+      }
+      value_bits = static_cast<IntType>(xor_val ^ prev_bits_);
+      prev_bits_ = value_bits;
+    }
+  }
+
+  if (offset_ != kDecodeButSkipStore) {
+    memcpy(dest_point_view.data() + offset_, &value_bits, sizeof(FloatType));
+  }
+
+  // Discard any padding bits remaining in the bit buffer so the next decode() starts on
+  // a byte boundary. Matches the per-call byte-alignment in FieldEncoderFloat_Gorilla.
+  bit_buf_ = 0;
+  bit_count_ = 0;
+}
+
+//------------------------------------------------------------------------------------------
 // Specialization for multiple consecutive floats
 class FieldDecoderFloatN_Lossy : public FieldDecoder {
  public:

--- a/cloudini_lib/include/cloudini_lib/field_encoder.hpp
+++ b/cloudini_lib/include/cloudini_lib/field_encoder.hpp
@@ -139,6 +139,179 @@ class FieldEncoderFloat_XOR : public FieldEncoder {
 };
 
 //------------------------------------------------------------------------------------------
+// Gorilla/Chimp-style bit-packed XOR for lossless float compression.
+// Encoding (per value after the first):
+//   - If XOR(curr, prev) == 0: emit 1 bit '0'.
+//   - Else emit '1'; if the non-zero window (leading_zeros, trailing_zeros) fits
+//     INSIDE the previously-emitted window (curr_leading >= prev_leading AND
+//     curr_trailing >= prev_trailing), emit '0' + meaningful bits (prev window size).
+//     Otherwise emit '1' + leading_zeros(5b) + meaningful_bit_count-1 (6b) + meaningful bits.
+// The first value is emitted raw (32 or 64 bits).
+//
+// IMPORTANT: to make the encoder composable with other byte-oriented encoders in the same
+// per-point loop (each field encoder writes to a shared output buffer), encode() flushes
+// its internal bit buffer to a byte boundary at the END of each call. This costs up to 7
+// padding bits per call but keeps each point's output contiguous per encoder.
+// flush() is retained for API symmetry but is a no-op for this class.
+template <typename FloatType>
+class FieldEncoderFloat_Gorilla : public FieldEncoder {
+ public:
+  FieldEncoderFloat_Gorilla(size_t field_offset) : offset_(field_offset) {
+    static_assert(std::is_floating_point<FloatType>::value, "FieldEncoderFloat_Gorilla requires a floating point type");
+  }
+
+  size_t encode(const ConstBufferView& point_view, BufferView& output) override;
+
+  // Flush partial bits to the next byte boundary. Returns number of bytes written.
+  size_t flush(BufferView& output) override;
+
+  void reset() override {
+    prev_bits_ = 0;
+    prev_leading_ = kLeadingSentinel;
+    prev_trailing_ = 0;
+    bit_buf_ = 0;
+    bit_count_ = 0;
+    first_ = true;
+  }
+
+ private:
+  using IntType = std::conditional_t<std::is_same<FloatType, float>::value, uint32_t, uint64_t>;
+  static constexpr size_t kTypeBits = sizeof(IntType) * 8;
+  static constexpr uint8_t kLeadingSentinel = 255;  // impossible-leading marker
+
+  // Writes `nbits` low bits of `bits` into the internal bit buffer, draining full bytes to `output`.
+  // Returns number of bytes written to `output`.
+  inline size_t putBits(uint64_t bits, uint8_t nbits, BufferView& output);
+
+  size_t offset_;
+  IntType prev_bits_ = 0;
+  uint8_t prev_leading_ = kLeadingSentinel;
+  uint8_t prev_trailing_ = 0;
+
+  // Internal bit accumulator: low-order bits are the earliest emitted.
+  // `bit_count_` is the number of valid bits currently held.
+  uint64_t bit_buf_ = 0;
+  uint8_t bit_count_ = 0;
+
+  bool first_ = true;
+};
+
+template <typename FloatType>
+inline size_t FieldEncoderFloat_Gorilla<FloatType>::putBits(uint64_t bits, uint8_t nbits, BufferView& output) {
+  // Mask to avoid polluting upper bits (for nbits < 64).
+  if (nbits < 64) {
+    bits &= (uint64_t{1} << nbits) - 1;
+  }
+  size_t bytes_written = 0;
+
+  // If inserting `nbits` at position `bit_count_` would overflow the 64-bit accumulator,
+  // split into two halves: emit the low `space = 64 - bit_count_` bits first, drain bytes,
+  // then emit the remaining high bits.
+  uint8_t space = static_cast<uint8_t>(64 - bit_count_);
+  if (nbits > space) {
+    // Low `space` bits first.
+    const uint64_t low_mask = (space == 64) ? ~uint64_t{0} : ((uint64_t{1} << space) - 1);
+    const uint64_t low_bits = bits & low_mask;
+    bit_buf_ |= (low_bits << bit_count_);
+    bit_count_ += space;
+    // Drain full bytes (bit_count_ is now 64).
+    while (bit_count_ >= 8) {
+      output.data()[0] = static_cast<uint8_t>(bit_buf_ & 0xFF);
+      output.trim_front(1);
+      bit_buf_ >>= 8;
+      bit_count_ -= 8;
+      ++bytes_written;
+    }
+    // Remaining high bits.
+    const uint8_t remaining = static_cast<uint8_t>(nbits - space);
+    const uint64_t high_bits = bits >> space;
+    bit_buf_ |= (high_bits << bit_count_);
+    bit_count_ += remaining;
+  } else {
+    bit_buf_ |= (bits << bit_count_);
+    bit_count_ += nbits;
+  }
+
+  while (bit_count_ >= 8) {
+    output.data()[0] = static_cast<uint8_t>(bit_buf_ & 0xFF);
+    output.trim_front(1);
+    bit_buf_ >>= 8;
+    bit_count_ -= 8;
+    ++bytes_written;
+  }
+  return bytes_written;
+}
+
+template <typename FloatType>
+inline size_t FieldEncoderFloat_Gorilla<FloatType>::encode(const ConstBufferView& point_view, BufferView& output) {
+  IntType current_val_uint;
+  memcpy(&current_val_uint, point_view.data() + offset_, sizeof(IntType));
+
+  size_t bytes_written = 0;
+
+  if (first_) {
+    // Emit the first value raw, 32 or 64 bits.
+    first_ = false;
+    prev_bits_ = current_val_uint;
+    bytes_written += putBits(static_cast<uint64_t>(current_val_uint), static_cast<uint8_t>(kTypeBits), output);
+  } else {
+    const IntType xor_val = current_val_uint ^ prev_bits_;
+    prev_bits_ = current_val_uint;
+
+    if (xor_val == 0) {
+      // Same value: single '0' bit.
+      bytes_written += putBits(0, 1, output);
+    } else {
+      // Non-zero XOR: emit '1' first.
+      bytes_written += putBits(1, 1, output);
+      const uint8_t leading = static_cast<uint8_t>(std::countl_zero(static_cast<IntType>(xor_val)));
+      const uint8_t trailing = static_cast<uint8_t>(std::countr_zero(static_cast<IntType>(xor_val)));
+
+      if (prev_leading_ != kLeadingSentinel && leading >= prev_leading_ && trailing >= prev_trailing_) {
+        // Fits inside previous window.
+        bytes_written += putBits(0, 1, output);
+        const uint8_t meaningful = static_cast<uint8_t>(kTypeBits - prev_leading_ - prev_trailing_);
+        const uint64_t bits = static_cast<uint64_t>(xor_val >> prev_trailing_);
+        bytes_written += putBits(bits, meaningful, output);
+      } else {
+        // New window.
+        bytes_written += putBits(1, 1, output);
+        uint8_t stored_leading = leading;
+        if (stored_leading > 31) {
+          stored_leading = 31;
+        }
+        const uint8_t meaningful = static_cast<uint8_t>(kTypeBits - stored_leading - trailing);
+        bytes_written += putBits(static_cast<uint64_t>(stored_leading), 5, output);
+        bytes_written += putBits(static_cast<uint64_t>(meaningful - 1), 6, output);
+        const uint64_t bits = static_cast<uint64_t>(xor_val >> trailing);
+        bytes_written += putBits(bits, meaningful, output);
+        prev_leading_ = stored_leading;
+        prev_trailing_ = trailing;
+      }
+    }
+  }
+
+  // Byte-align: flush any partial byte to the output so each encode() call produces a
+  // contiguous byte stream. This is what lets the encoder compose with other byte-oriented
+  // encoders in the shared per-point output buffer.
+  if (bit_count_ > 0) {
+    output.data()[0] = static_cast<uint8_t>(bit_buf_ & 0xFF);
+    output.trim_front(1);
+    bit_buf_ = 0;
+    bit_count_ = 0;
+    ++bytes_written;
+  }
+
+  return bytes_written;
+}
+
+template <typename FloatType>
+inline size_t FieldEncoderFloat_Gorilla<FloatType>::flush(BufferView& /*output*/) {
+  // Per-call byte-alignment in encode() leaves nothing to flush at chunk boundaries.
+  return 0;
+}
+
+//------------------------------------------------------------------------------------------
 // Specialization for points XYZ and XYZI
 class FieldEncoderFloatN_Lossy : public FieldEncoder {
  public:

--- a/cloudini_lib/src/cloudini.cpp
+++ b/cloudini_lib/src/cloudini.cpp
@@ -316,12 +316,14 @@ size_t MaxCompressedSize(const EncodingInfo& info, size_t points_count, bool inc
 void EncodeHeader(const EncodingInfo& header, std::vector<uint8_t>& output, HeaderEncoding encoding) {
   output.clear();
 
-  auto write_magic = [](BufferView& output_buffer) {
+  auto write_magic = [&header](BufferView& output_buffer) {
     memcpy(output_buffer.data(), kMagicHeader, kMagicHeaderLength);
     output_buffer.trim_front(kMagicHeaderLength);
-    // version as two ASCII digits
-    encode<char>('0' + (kEncodingVersion / 10), output_buffer);
-    encode<char>('0' + (kEncodingVersion % 10), output_buffer);
+    // version as two ASCII digits. Respects header.version so callers can request
+    // an older wire format (e.g. v3) for backward compatibility with old readers.
+    const uint8_t v = header.version;
+    encode<char>('0' + (v / 10), output_buffer);
+    encode<char>('0' + (v % 10), output_buffer);
   };
 
   if (encoding == HeaderEncoding::YAML) {
@@ -406,7 +408,11 @@ EncodingInfo DecodeHeader(ConstBufferView& input) {
     }
     yaml_str = yaml_str.substr(0, null_pos);
     input.trim_front(null_pos + 1);  // consume header + null terminator
-    return EncodingInfoFromYAML(yaml_str);
+    EncodingInfo yaml_header = EncodingInfoFromYAML(yaml_str);
+    // The magic-header version is authoritative. YAML's parseScalar<uint8_t> reads a
+    // single character (e.g. "3" -> 51), so the YAML-parsed info.version is unreliable.
+    yaml_header.version = version;
+    return yaml_header;
   }
 
   // Binary encoded header
@@ -490,11 +496,7 @@ PointcloudEncoder::PointcloudEncoder(const EncodingInfo& info) : info_(info) {
         if (info_.encoding_opt == EncodingOptions::LOSSY && field.resolution.has_value()) {
           encoders_.push_back(std::make_unique<FieldEncoderFloat_Lossy<float>>(offset, *field.resolution));
         } else if (info_.encoding_opt == EncodingOptions::LOSSLESS) {
-          if (info_.version >= 4) {
-            encoders_.push_back(std::make_unique<FieldEncoderFloat_Gorilla<float>>(offset));
-          } else {
-            encoders_.push_back(std::make_unique<FieldEncoderFloat_XOR<float>>(offset));
-          }
+          encoders_.push_back(std::make_unique<FieldEncoderFloat_XOR<float>>(offset));
         } else {
           encoders_.push_back(std::make_unique<FieldEncoderCopy>(offset, field.type));
         }
@@ -503,7 +505,9 @@ PointcloudEncoder::PointcloudEncoder(const EncodingInfo& info) : info_(info) {
       case FieldType::FLOAT64: {
         if (info_.encoding_opt == EncodingOptions::LOSSY && field.resolution.has_value()) {
           encoders_.push_back(std::make_unique<FieldEncoderFloat_Lossy<double>>(offset, *field.resolution));
-        } else if (info_.version >= 4) {
+        } else if (!field.resolution.has_value() && info_.version >= 4) {
+          // FLOAT64 without a resolution is treated as lossless (even when encoding_opt == LOSSY).
+          // On v4, use Gorilla bit-packing; on v3 and earlier, use raw XOR.
           encoders_.push_back(std::make_unique<FieldEncoderFloat_Gorilla<double>>(offset));
         } else {
           encoders_.push_back(std::make_unique<FieldEncoderFloat_XOR<double>>(offset));
@@ -799,11 +803,7 @@ void PointcloudDecoder::updateDecoders(const EncodingInfo& info) {
         if (info.encoding_opt == EncodingOptions::LOSSY && field.resolution) {
           return std::make_unique<FieldDecoderFloat_Lossy<float>>(offset, *field.resolution);
         } else if (info.encoding_opt == EncodingOptions::LOSSLESS) {
-          if (info.version >= 4) {
-            return std::make_unique<FieldDecoderFloat_Gorilla<float>>(offset);
-          } else {
-            return std::make_unique<FieldDecoderFloat_XOR<float>>(offset);
-          }
+          return std::make_unique<FieldDecoderFloat_XOR<float>>(offset);
         } else if (field.resolution) {
           // Legacy compatibility: if resolution is set but encoding_opt is not LOSSY.
           return std::make_unique<FieldDecoderFloat_Lossy<float>>(offset, *field.resolution);
@@ -816,7 +816,8 @@ void PointcloudDecoder::updateDecoders(const EncodingInfo& info) {
           return std::make_unique<FieldDecoderFloat_Lossy<double>>(offset, *field.resolution);
         } else if (field.resolution && info.encoding_opt != EncodingOptions::LOSSLESS) {
           return std::make_unique<FieldDecoderFloat_Lossy<double>>(offset, *field.resolution);
-        } else if (info.version >= 4) {
+        } else if (!field.resolution && info.version >= 4) {
+          // FLOAT64 without a resolution is treated as lossless regardless of encoding_opt.
           return std::make_unique<FieldDecoderFloat_Gorilla<double>>(offset);
         } else {
           return std::make_unique<FieldDecoderFloat_XOR<double>>(offset);

--- a/cloudini_lib/src/cloudini.cpp
+++ b/cloudini_lib/src/cloudini.cpp
@@ -247,12 +247,15 @@ size_t MaxSerializedFieldSize(const PointField& field, EncodingOptions encoding_
       if (encoding_opt == EncodingOptions::LOSSY && field.resolution.has_value()) {
         return 10;  // quantized int64 delta as varint
       }
-      return sizeof(float);
+      // Gorilla worst-case bits: 1 (flag) + 1 (control) + 5 (leading) + 6 (length) + 32 (bits) = 45 bits.
+      // With byte-alignment slop from other fields + final flush, 7 bytes is a safe upper bound per value.
+      return 7;
     case FieldType::FLOAT64:
       if (encoding_opt == EncodingOptions::LOSSY && field.resolution.has_value()) {
         return 10;  // quantized int64 delta as varint
       }
-      return sizeof(double);  // XOR residual
+      // Gorilla worst-case bits: 1 + 1 + 5 + 6 + 64 = 77 bits → 10 bytes.
+      return 11;  // XOR residual or Gorilla bit-pack, rounded up
     case FieldType::INT8:
     case FieldType::UINT8:
       return 1;
@@ -389,6 +392,8 @@ EncodingInfo DecodeHeader(ConstBufferView& input) {
         "Unsupported encoding version. Current is:" + std::to_string(kEncodingVersion) +
         ", got: " + std::to_string(version));
   }
+  // Note: version 4 adds Gorilla bit-packing for lossless FLOAT32/FLOAT64 XOR residuals.
+  // Versions 2 and 3 keep the raw-XOR path (8 bytes per double, 4 bytes per float).
 
   // check if encoded as YAML (starts with newline after version, then non-brace character)
   if (input.size() >= 2 && input.data()[0] == '\n' && input.data()[1] != '{') {
@@ -484,6 +489,12 @@ PointcloudEncoder::PointcloudEncoder(const EncodingInfo& info) : info_(info) {
       case FieldType::FLOAT32: {
         if (info_.encoding_opt == EncodingOptions::LOSSY && field.resolution.has_value()) {
           encoders_.push_back(std::make_unique<FieldEncoderFloat_Lossy<float>>(offset, *field.resolution));
+        } else if (info_.encoding_opt == EncodingOptions::LOSSLESS) {
+          if (info_.version >= 4) {
+            encoders_.push_back(std::make_unique<FieldEncoderFloat_Gorilla<float>>(offset));
+          } else {
+            encoders_.push_back(std::make_unique<FieldEncoderFloat_XOR<float>>(offset));
+          }
         } else {
           encoders_.push_back(std::make_unique<FieldEncoderCopy>(offset, field.type));
         }
@@ -492,6 +503,8 @@ PointcloudEncoder::PointcloudEncoder(const EncodingInfo& info) : info_(info) {
       case FieldType::FLOAT64: {
         if (info_.encoding_opt == EncodingOptions::LOSSY && field.resolution.has_value()) {
           encoders_.push_back(std::make_unique<FieldEncoderFloat_Lossy<double>>(offset, *field.resolution));
+        } else if (info_.version >= 4) {
+          encoders_.push_back(std::make_unique<FieldEncoderFloat_Gorilla<double>>(offset));
         } else {
           encoders_.push_back(std::make_unique<FieldEncoderFloat_XOR<double>>(offset));
         }
@@ -690,7 +703,10 @@ size_t PointcloudEncoder::encode(ConstBufferView cloud_data, BufferView& output,
     compressed_size_ += header_.size();
     output_view_.trim_front(header_.size());
   }
-  const size_t kChunkSize = POINTS_PER_CHUNK * info_.point_step;
+  // Stage-1 output per point can exceed point_step in lossless mode (e.g. Gorilla may emit
+  // up to 7 bytes for a FLOAT32, or 11 for a FLOAT64). Size the staging buffer accordingly.
+  const size_t max_per_point = MaxSerializedPointSize(info_);
+  const size_t kChunkSize = POINTS_PER_CHUNK * std::max<size_t>(info_.point_step, max_per_point);
 
   buffer_.resize(kChunkSize);
   BufferView buffer_view(buffer_);
@@ -706,6 +722,10 @@ size_t PointcloudEncoder::encode(ConstBufferView cloud_data, BufferView& output,
     points_in_current_chunk++;
     // end of chunk ?
     if (points_in_current_chunk >= POINTS_PER_CHUNK || cloud_data.empty()) {
+      // flush any per-encoder buffered bits/bytes (e.g. Gorilla bit-packer) before stage 2
+      for (auto& encoder : encoders_) {
+        serialized_size += encoder->flush(buffer_view);
+      }
       // simple case: no compression. Execute in the same thread
       if (info_.compression_opt == CompressionOption::NONE) {
         Cloudini::encode(static_cast<uint32_t>(serialized_size), output_view_);
@@ -772,19 +792,32 @@ size_t PointcloudEncoder::encode(ConstBufferView cloud_data, BufferView& output,
 //------------------------------------------------------------------------------------------
 
 void PointcloudDecoder::updateDecoders(const EncodingInfo& info) {
-  auto create_decoder = [](const PointField& field) -> std::unique_ptr<FieldDecoder> {
+  auto create_decoder = [&info](const PointField& field) -> std::unique_ptr<FieldDecoder> {
     const auto offset = field.offset;
     switch (field.type) {
       case FieldType::FLOAT32:
-        if (field.resolution) {
+        if (info.encoding_opt == EncodingOptions::LOSSY && field.resolution) {
+          return std::make_unique<FieldDecoderFloat_Lossy<float>>(offset, *field.resolution);
+        } else if (info.encoding_opt == EncodingOptions::LOSSLESS) {
+          if (info.version >= 4) {
+            return std::make_unique<FieldDecoderFloat_Gorilla<float>>(offset);
+          } else {
+            return std::make_unique<FieldDecoderFloat_XOR<float>>(offset);
+          }
+        } else if (field.resolution) {
+          // Legacy compatibility: if resolution is set but encoding_opt is not LOSSY.
           return std::make_unique<FieldDecoderFloat_Lossy<float>>(offset, *field.resolution);
         } else {
           return std::make_unique<FieldDecoderCopy>(field.offset, field.type);
         }
         break;
       case FieldType::FLOAT64:
-        if (field.resolution) {
+        if (info.encoding_opt == EncodingOptions::LOSSY && field.resolution) {
           return std::make_unique<FieldDecoderFloat_Lossy<double>>(offset, *field.resolution);
+        } else if (field.resolution && info.encoding_opt != EncodingOptions::LOSSLESS) {
+          return std::make_unique<FieldDecoderFloat_Lossy<double>>(offset, *field.resolution);
+        } else if (info.version >= 4) {
+          return std::make_unique<FieldDecoderFloat_Gorilla<double>>(offset);
         } else {
           return std::make_unique<FieldDecoderFloat_XOR<double>>(offset);
         }
@@ -865,6 +898,8 @@ void PointcloudDecoder::decode(const EncodingInfo& info, ConstBufferView compres
   }
 
   if (info.version >= 3) {
+    const size_t kChunkPoints = 32 * 1024;  // must match PointcloudEncoder::POINTS_PER_CHUNK
+    size_t points_remaining = static_cast<size_t>(info.width) * static_cast<size_t>(info.height);
     while (!compressed_data.empty()) {
       uint32_t chunk_size = 0;
       Cloudini::decode(compressed_data, chunk_size);
@@ -872,15 +907,18 @@ void PointcloudDecoder::decode(const EncodingInfo& info, ConstBufferView compres
         throw std::runtime_error("Invalid chunk size found while decoding");
       }
       ConstBufferView chunk_view(compressed_data.data(), chunk_size);
-      decodeChunk(info, chunk_view, output);
+      const size_t points_in_chunk = std::min(points_remaining, kChunkPoints);
+      decodeChunk(info, chunk_view, output, points_in_chunk);
       compressed_data.trim_front(chunk_size);
+      points_remaining -= points_in_chunk;
     }
   } else {
-    decodeChunk(info, compressed_data, output);
+    decodeChunk(info, compressed_data, output, /*expected_points=*/0);
   }
 }
 
-void PointcloudDecoder::decodeChunk(const EncodingInfo& info, ConstBufferView chunk_data, BufferView& output_buffer) {
+void PointcloudDecoder::decodeChunk(
+    const EncodingInfo& info, ConstBufferView chunk_data, BufferView& output_buffer, size_t expected_points) {
   // allocate sufficient space in the buffer
   decompressed_buffer_.resize(info.width * info.height * info.point_step);
 
@@ -920,18 +958,35 @@ void PointcloudDecoder::decodeChunk(const EncodingInfo& info, ConstBufferView ch
     decoder->reset();
   }
 
-  while (encoded_view.size() > 0) {
-    if (encoded_view.size() < min_encoded_point_bytes_) {
-      throw std::runtime_error("Truncated encoded data: not enough bytes for a complete point");
+  if (expected_points > 0) {
+    // Chunked (v3+) path: decode exactly `expected_points` points. Byte-based termination
+    // cannot be used because some field decoders (e.g. Gorilla bit-packing) consume bytes
+    // non-uniformly across points.
+    for (size_t p = 0; p < expected_points; ++p) {
+      if (output_buffer.size() < info.point_step) {
+        throw std::runtime_error("Output buffer is too small to hold the decoded data");
+      }
+      BufferView point_view(output_buffer.data(), info.point_step);
+      for (auto& decoder : decoders_) {
+        decoder->decode(encoded_view, point_view);
+      }
+      output_buffer.trim_front(info.point_step);
     }
-    if (output_buffer.size() < info.point_step) {
-      throw std::runtime_error("Output buffer is too small to hold the decoded data");
+  } else {
+    // Legacy (v2) path: terminate when input bytes are exhausted.
+    while (encoded_view.size() > 0) {
+      if (encoded_view.size() < min_encoded_point_bytes_) {
+        throw std::runtime_error("Truncated encoded data: not enough bytes for a complete point");
+      }
+      if (output_buffer.size() < info.point_step) {
+        throw std::runtime_error("Output buffer is too small to hold the decoded data");
+      }
+      BufferView point_view(output_buffer.data(), info.point_step);
+      for (auto& decoder : decoders_) {
+        decoder->decode(encoded_view, point_view);
+      }
+      output_buffer.trim_front(info.point_step);
     }
-    BufferView point_view(output_buffer.data(), info.point_step);
-    for (auto& decoder : decoders_) {
-      decoder->decode(encoded_view, point_view);
-    }
-    output_buffer.trim_front(info.point_step);
   }
 }
 

--- a/cloudini_lib/test/test_field_encoders.cpp
+++ b/cloudini_lib/test/test_field_encoders.cpp
@@ -19,8 +19,11 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <cstring>
 #include <limits>
+#include <random>
 
+#include "cloudini_lib/cloudini.hpp"
 #include "cloudini_lib/field_decoder.hpp"
 #include "cloudini_lib/field_encoder.hpp"
 
@@ -137,6 +140,235 @@ TEST(FieldEncoders, FloatLossy) {
       ASSERT_NEAR(input_data[i], output_data[i], kTolerance) << "Mismatch at index " << i;
     }
     std::cout << "Max difference: " << max_difference << std::endl;
+  }
+}
+
+namespace {
+
+// Helper: round-trip a sequence of FloatType values through encoder/decoder,
+// periodically flushing+resetting both at chunk boundaries to exercise the
+// chunk-flush path (the classic bit-packer gotcha).
+template <typename EncoderT, typename DecoderT, typename FloatType>
+void runFieldRoundTrip(const std::vector<FloatType>& input, size_t chunk_points, size_t worst_case_bytes_per_value) {
+  using namespace Cloudini;
+
+  const size_t n = input.size();
+  std::vector<uint8_t> buffer(std::max<size_t>(n * worst_case_bytes_per_value + 16, 64));
+  BufferView buf_view(buffer.data(), buffer.size());
+
+  EncoderT encoder(0);
+  size_t encoded_bytes = 0;
+  size_t points_in_chunk = 0;
+  // Chunk boundaries: after every `chunk_points` we flush+reset the encoder,
+  // emulating what PointcloudEncoder does at chunk boundaries.
+  for (size_t i = 0; i < n; ++i) {
+    ConstBufferView point_view(reinterpret_cast<const uint8_t*>(&input[i]), sizeof(FloatType));
+    encoded_bytes += encoder.encode(point_view, buf_view);
+    points_in_chunk++;
+    if (points_in_chunk >= chunk_points || i + 1 == n) {
+      encoded_bytes += encoder.flush(buf_view);
+      encoder.reset();
+      points_in_chunk = 0;
+    }
+  }
+
+  // Decode
+  std::vector<FloatType> output(n, FloatType{0});
+  DecoderT decoder(0);
+  ConstBufferView enc_view(buffer.data(), encoded_bytes);
+
+  size_t chunk_remaining = 0;
+  size_t idx = 0;
+  while (idx < n) {
+    if (chunk_remaining == 0) {
+      chunk_remaining = std::min(chunk_points, n - idx);
+      decoder.reset();
+    }
+    BufferView point_view(reinterpret_cast<uint8_t*>(&output[idx]), sizeof(FloatType));
+    decoder.decode(enc_view, point_view);
+    idx++;
+    chunk_remaining--;
+  }
+
+  // Exact bit-for-bit equality for lossless
+  for (size_t i = 0; i < n; ++i) {
+    using IntT = std::conditional_t<std::is_same<FloatType, float>::value, uint32_t, uint64_t>;
+    IntT a_bits, b_bits;
+    std::memcpy(&a_bits, &input[i], sizeof(FloatType));
+    std::memcpy(&b_bits, &output[i], sizeof(FloatType));
+    ASSERT_EQ(a_bits, b_bits) << "Mismatch at index " << i << " input=" << input[i] << " output=" << output[i];
+  }
+}
+
+}  // namespace
+
+TEST(FieldEncoders, FloatXOR_RoundTrip_Float32) {
+  // Multi-chunk test: ensures the chunk-boundary reset path is covered.
+  const size_t kChunkPoints = 32 * 1024;            // must match PointcloudEncoder::POINTS_PER_CHUNK
+  const size_t kNumpoints = kChunkPoints * 3 + 17;  // cross chunk boundary several times
+
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<float> dist(-1000.0f, 1000.0f);
+  std::vector<float> input(kNumpoints);
+  for (auto& v : input) {
+    v = dist(rng);
+  }
+
+  using namespace Cloudini;
+  runFieldRoundTrip<FieldEncoderFloat_XOR<float>, FieldDecoderFloat_XOR<float>, float>(
+      input, kChunkPoints, sizeof(float));
+}
+
+TEST(FieldEncoders, FloatXOR_RoundTrip_Float64) {
+  const size_t kChunkPoints = 32 * 1024;
+  const size_t kNumpoints = kChunkPoints * 2 + 99;
+
+  std::mt19937 rng(123);
+  std::uniform_real_distribution<double> dist(-1e6, 1e6);
+  std::vector<double> input(kNumpoints);
+  for (auto& v : input) {
+    v = dist(rng);
+  }
+
+  using namespace Cloudini;
+  runFieldRoundTrip<FieldEncoderFloat_XOR<double>, FieldDecoderFloat_XOR<double>, double>(
+      input, kChunkPoints, sizeof(double));
+}
+
+TEST(FieldEncoders, FloatGorilla_RoundTrip_Float32) {
+  const size_t kChunkPoints = 32 * 1024;
+  const size_t kNumpoints = kChunkPoints * 3 + 17;
+
+  std::mt19937 rng(7);
+  std::uniform_real_distribution<float> dist(-1000.0f, 1000.0f);
+  std::vector<float> input(kNumpoints);
+  for (auto& v : input) {
+    v = dist(rng);
+  }
+  // Also include some repeated values to exercise the "same as prev" 1-bit path.
+  for (size_t i = 100; i < 110; ++i) {
+    input[i] = 3.14159f;
+  }
+  // And values near chunk boundary
+  input[kChunkPoints - 1] = 1.0f;
+  input[kChunkPoints] = 1.0f;
+  input[kChunkPoints + 1] = 2.0f;
+
+  using namespace Cloudini;
+  runFieldRoundTrip<FieldEncoderFloat_Gorilla<float>, FieldDecoderFloat_Gorilla<float>, float>(input, kChunkPoints, 7);
+}
+
+TEST(FieldEncoders, FloatGorilla_RoundTrip_Float64) {
+  const size_t kChunkPoints = 32 * 1024;
+  const size_t kNumpoints = kChunkPoints * 2 + 123;
+
+  std::mt19937 rng(99);
+  std::uniform_real_distribution<double> dist(-1e6, 1e6);
+  std::vector<double> input(kNumpoints);
+  for (auto& v : input) {
+    v = dist(rng);
+  }
+  for (size_t i = 200; i < 220; ++i) {
+    input[i] = 2.718281828;
+  }
+  input[kChunkPoints - 1] = -0.5;
+  input[kChunkPoints] = -0.5;
+
+  using namespace Cloudini;
+  runFieldRoundTrip<FieldEncoderFloat_Gorilla<double>, FieldDecoderFloat_Gorilla<double>, double>(
+      input, kChunkPoints, 11);
+}
+
+TEST(FieldEncoders, FloatGorilla_EdgeCases_Float32) {
+  // Deterministic edge cases: first value, zero, repeats, big jump, near-zero.
+  std::vector<float> input = {
+      0.0f,        // first value
+      0.0f,        // same
+      0.0f,        // same
+      1.0f,        // big change
+      1.0000001f,  // small change - tests window reuse
+      1.0f,        // back
+      1e-20f,      // tiny
+      1e20f,       // huge
+      std::numeric_limits<float>::infinity(),
+      -std::numeric_limits<float>::infinity(),
+  };
+  using namespace Cloudini;
+  runFieldRoundTrip<FieldEncoderFloat_Gorilla<float>, FieldDecoderFloat_Gorilla<float>, float>(
+      input, /*chunk_points=*/input.size() + 1, 7);
+}
+
+// Full PointcloudEncoder/Decoder round-trip in LOSSLESS mode, > POINTS_PER_CHUNK points,
+// covers the full chunk-flush integration.
+TEST(FieldEncoders, PointcloudLossless_Gorilla_MultiChunk) {
+  using namespace Cloudini;
+
+  struct PointXYZI {
+    float x = 0;
+    float y = 0;
+    float z = 0;
+    float i = 0;
+  };
+
+  const size_t kChunkPoints = 32 * 1024;
+  const size_t kNumpoints = kChunkPoints * 2 + 777;  // multi-chunk
+
+  std::mt19937 rng(2025);
+  std::uniform_real_distribution<float> dist_pos(-500.0f, 500.0f);
+  std::uniform_real_distribution<float> dist_i(0.0f, 255.0f);
+
+  std::vector<PointXYZI> input(kNumpoints);
+  for (auto& p : input) {
+    p.x = dist_pos(rng);
+    p.y = dist_pos(rng);
+    p.z = dist_pos(rng);
+    p.i = dist_i(rng);
+  }
+
+  EncodingInfo info;
+  info.width = kNumpoints;
+  info.height = 1;
+  info.point_step = sizeof(PointXYZI);
+  info.encoding_opt = EncodingOptions::LOSSLESS;
+  info.compression_opt = CompressionOption::ZSTD;
+  info.fields.push_back({"x", 0, FieldType::FLOAT32, {}});
+  info.fields.push_back({"y", 4, FieldType::FLOAT32, {}});
+  info.fields.push_back({"z", 8, FieldType::FLOAT32, {}});
+  info.fields.push_back({"intensity", 12, FieldType::FLOAT32, {}});
+
+  std::vector<uint8_t> compressed;
+  {
+    PointcloudEncoder encoder(info);
+    ConstBufferView in_view(reinterpret_cast<const uint8_t*>(input.data()), input.size() * sizeof(PointXYZI));
+    encoder.encode(in_view, compressed);
+  }
+
+  ConstBufferView comp_view(compressed.data(), compressed.size());
+  auto decoded_info = DecodeHeader(comp_view);
+  ASSERT_EQ(decoded_info.encoding_opt, EncodingOptions::LOSSLESS);
+
+  std::vector<PointXYZI> output(kNumpoints);
+  {
+    PointcloudDecoder decoder;
+    BufferView out_view(reinterpret_cast<uint8_t*>(output.data()), output.size() * sizeof(PointXYZI));
+    decoder.decode(decoded_info, comp_view, out_view);
+  }
+
+  // Bit-exact equality for lossless.
+  for (size_t i = 0; i < kNumpoints; ++i) {
+    uint32_t a, b;
+    std::memcpy(&a, &input[i].x, 4);
+    std::memcpy(&b, &output[i].x, 4);
+    ASSERT_EQ(a, b) << "x at " << i;
+    std::memcpy(&a, &input[i].y, 4);
+    std::memcpy(&b, &output[i].y, 4);
+    ASSERT_EQ(a, b) << "y at " << i;
+    std::memcpy(&a, &input[i].z, 4);
+    std::memcpy(&b, &output[i].z, 4);
+    ASSERT_EQ(a, b) << "z at " << i;
+    std::memcpy(&a, &input[i].i, 4);
+    std::memcpy(&b, &output[i].i, 4);
+    ASSERT_EQ(a, b) << "intensity at " << i;
   }
 }
 

--- a/cloudini_lib/test/test_field_encoders.cpp
+++ b/cloudini_lib/test/test_field_encoders.cpp
@@ -434,3 +434,75 @@ TEST(FieldEncoders, PointcloudLossless_Gorilla_MultiChunk) {
 //     }
 //   }
 // }
+
+// Regression guard for the Gorilla narrowing: when info.version = 3, a FLOAT64
+// lossless field MUST go through FieldEncoderFloat_XOR (raw 8 bytes per value),
+// not Gorilla. A v4 encode of the same data uses Gorilla and produces a
+// different byte stream. This locks the dispatch narrowing in place.
+TEST(FieldEncoders, Gorilla_DoesNotActivateForV3) {
+  using namespace Cloudini;
+
+  const size_t n = 1024;
+  std::vector<double> input(n);
+  // Monotonic-ish timestamps: Gorilla's best case (huge trailing-zero runs in XOR).
+  // If Gorilla were wrongly activated on v3, the v3 output would be much
+  // smaller than raw XOR bytes and would MATCH the v4 output.
+  for (size_t i = 0; i < n; ++i) {
+    input[i] = 1700000000.0 + 1e-6 * static_cast<double>(i);
+  }
+
+  auto make_info = [n](uint8_t version) {
+    EncodingInfo info;
+    info.version = version;
+    info.width = static_cast<uint32_t>(n);
+    info.height = 1;
+    info.point_step = sizeof(double);
+    info.encoding_opt = EncodingOptions::LOSSLESS;
+    info.compression_opt = CompressionOption::NONE;  // inspect raw stage-1 bytes
+    info.use_threads = false;
+    info.fields.push_back({"v", 0, FieldType::FLOAT64, std::nullopt});
+    return info;
+  };
+
+  std::vector<uint8_t> out_v3, out_v4;
+  {
+    auto info3 = make_info(3);
+    PointcloudEncoder enc3(info3);
+    ConstBufferView in(reinterpret_cast<const uint8_t*>(input.data()), input.size() * sizeof(double));
+    enc3.encode(in, out_v3);
+  }
+  {
+    auto info4 = make_info(4);
+    PointcloudEncoder enc4(info4);
+    ConstBufferView in(reinterpret_cast<const uint8_t*>(input.data()), input.size() * sizeof(double));
+    enc4.encode(in, out_v4);
+  }
+
+  // v3 magic must start with CLOUDINI_V03; v4 with CLOUDINI_V04.
+  ASSERT_GE(out_v3.size(), 12u);
+  ASSERT_GE(out_v4.size(), 12u);
+  EXPECT_EQ(std::string(reinterpret_cast<const char*>(out_v3.data()), 12), "CLOUDINI_V03");
+  EXPECT_EQ(std::string(reinterpret_cast<const char*>(out_v4.data()), 12), "CLOUDINI_V04");
+
+  // The byte streams must differ: v3 uses raw 8-byte XOR residuals, v4 uses
+  // bit-packed Gorilla. For monotonic timestamps Gorilla is substantially
+  // smaller than XOR — so out_v4.size() must be STRICTLY less than out_v3.size().
+  EXPECT_LT(out_v4.size(), out_v3.size())
+      << "Gorilla (v4) should compress monotonic FLOAT64 better than plain XOR (v3).";
+
+  // Both must still round-trip bit-exactly.
+  for (auto& blob : {std::cref(out_v3), std::cref(out_v4)}) {
+    ConstBufferView view(blob.get().data(), blob.get().size());
+    auto info_dec = DecodeHeader(view);
+    std::vector<double> output(n, 0.0);
+    PointcloudDecoder dec;
+    BufferView out_view(reinterpret_cast<uint8_t*>(output.data()), output.size() * sizeof(double));
+    dec.decode(info_dec, view, out_view);
+    for (size_t i = 0; i < n; ++i) {
+      uint64_t a, b;
+      std::memcpy(&a, &input[i], sizeof(double));
+      std::memcpy(&b, &output[i], sizeof(double));
+      ASSERT_EQ(a, b) << "Bit mismatch at " << i << " (version " << static_cast<int>(info_dec.version) << ")";
+    }
+  }
+}

--- a/cloudini_lib/test/test_header.cpp
+++ b/cloudini_lib/test/test_header.cpp
@@ -61,6 +61,76 @@ TEST(Cloudini, HeaderTruncatedInput) {
   EXPECT_THROW(DecodeHeader(input), std::runtime_error);
 }
 
+TEST(Cloudini, DecodeV3_FromLegacyEncoder) {
+  using namespace Cloudini;
+
+  // Backward-compat contract: files written with the v3 wire format must still
+  // decode correctly with the current (v4-capable) library. We simulate v3 by
+  // setting info.version = 3 on the encoder. EncodeHeader honors this to write
+  // a "03" magic header, and the dispatch code selects the v3 encoders
+  // (FieldEncoderFloat_XOR for FLOAT64 lossless, no Gorilla).
+  struct Point {
+    float x, y, z;
+    double stamp;
+  };
+  static_assert(sizeof(Point) == 24, "unexpected layout");
+
+  const size_t n = 64 * 1024 + 7;  // multi-chunk (POINTS_PER_CHUNK = 32K)
+  std::vector<Point> input(n);
+  for (size_t i = 0; i < n; ++i) {
+    input[i].x = 0.01f * static_cast<float>(i);
+    input[i].y = -0.02f * static_cast<float>(i) + 0.5f;
+    input[i].z = 0.001f * static_cast<float>(i) - 0.25f;
+    input[i].stamp = 1700000000.0 + 0.000001 * static_cast<double>(i);  // monotonic timestamp
+  }
+
+  EncodingInfo info;
+  info.version = 3;  // force v3 wire format
+  info.width = static_cast<uint32_t>(n);
+  info.height = 1;
+  info.point_step = sizeof(Point);
+  info.encoding_opt = EncodingOptions::LOSSY;
+  info.compression_opt = CompressionOption::ZSTD;
+  info.fields.push_back({"x", 0, FieldType::FLOAT32, 0.001f});
+  info.fields.push_back({"y", 4, FieldType::FLOAT32, 0.001f});
+  info.fields.push_back({"z", 8, FieldType::FLOAT32, 0.001f});
+  info.fields.push_back({"stamp", 16, FieldType::FLOAT64, std::nullopt});  // lossless
+
+  std::vector<uint8_t> compressed;
+  {
+    PointcloudEncoder encoder(info);
+    ConstBufferView in_view(reinterpret_cast<const uint8_t*>(input.data()), input.size() * sizeof(Point));
+    encoder.encode(in_view, compressed);
+  }
+
+  // Verify the written magic is "CLOUDINI_V03" (v3), not v4.
+  ASSERT_GE(compressed.size(), 12u);
+  ASSERT_EQ(std::string(reinterpret_cast<const char*>(compressed.data()), 12), "CLOUDINI_V03");
+
+  ConstBufferView compressed_view(compressed.data(), compressed.size());
+  const auto decoded_info = DecodeHeader(compressed_view);
+  ASSERT_EQ(decoded_info.version, 3);
+
+  std::vector<Point> output(n);
+  {
+    PointcloudDecoder decoder;
+    BufferView out_view(reinterpret_cast<uint8_t*>(output.data()), output.size() * sizeof(Point));
+    decoder.decode(decoded_info, compressed_view, out_view);
+  }
+
+  const float tol = 0.001f * 1.01f;
+  for (size_t i = 0; i < n; ++i) {
+    ASSERT_NEAR(input[i].x, output[i].x, tol) << "x @" << i;
+    ASSERT_NEAR(input[i].y, output[i].y, tol) << "y @" << i;
+    ASSERT_NEAR(input[i].z, output[i].z, tol) << "z @" << i;
+    // stamp is LOSSLESS — expect bit-exact via XOR path
+    uint64_t a, b;
+    std::memcpy(&a, &input[i].stamp, sizeof(double));
+    std::memcpy(&b, &output[i].stamp, sizeof(double));
+    ASSERT_EQ(a, b) << "stamp @" << i;
+  }
+}
+
 TEST(Cloudini, HeaderMissingYamlTerminator) {
   using namespace Cloudini;
 

--- a/cloudini_ros/CMakeLists.txt
+++ b/cloudini_ros/CMakeLists.txt
@@ -135,7 +135,14 @@ target_link_libraries(test_plugin_subscriber
   point_cloud_transport::point_cloud_transport
 )
 
-ament_target_dependencies(test_plugin_subscriber pcl_conversions)
+# pcl_conversions exports:
+#   - old style (Humble/Jazzy): ament_export_include_directories -> sets _INCLUDE_DIRS
+#   - new style (Kilted+): ament_export_targets -> sets _TARGETS
+# ament_target_dependencies handled both but was removed in Rolling. Apply both
+# the modern _TARGETS link AND the legacy _INCLUDE_DIRS include. Each is a no-op
+# when undefined, so a single recipe works across Humble, Jazzy, Kilted, Rolling.
+target_link_libraries(test_plugin_subscriber ${pcl_conversions_TARGETS})
+target_include_directories(test_plugin_subscriber PRIVATE ${pcl_conversions_INCLUDE_DIRS})
 
 install(TARGETS test_plugin_subscriber
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
## Summary

- Adds a Gorilla-style bit-packed XOR encoder for **FLOAT64 lossless** fields (version 4 wire format); FLOAT32 lossless keeps the existing XOR path.
- Real-rosbag compression ratios drop sharply on streams carrying per-point FLOAT64 timestamps: bount **0.585 → 0.316** (−46 %), north1 **0.569 → 0.300** (−47 %). Streams without FLOAT64 (dexory) are unchanged.
- Backward-compatible: v2 and v3 files decode correctly under this branch. An explicit v3-write escape hatch is provided by setting `info.version = 3`.

## What changed

**Stage-1 encoder** (`cloudini_lib/src/cloudini.cpp`):
- New `FieldEncoderFloat_Gorilla<double>` / `FieldDecoderFloat_Gorilla<double>` used when `FLOAT64`, no resolution, and `info.version >= 4`. Otherwise plain `FieldEncoderFloat_XOR<double>`.
- FLOAT32 lossless always uses plain XOR regardless of version (avoids the regression seen when FLOAT32 was also routed through Gorilla).

**Wire-format / backward compat fixes:**
- `write_magic` now honors `header.version`, so callers can request v3-compatible output by setting `info.version = 3`.
- `DecodeHeader`, on the YAML path, overrides the YAML-parsed version with the authoritative magic-byte version. Pre-existing YAML bug: `parseScalar<uint8_t>` uses `istringstream >>` on `unsigned char`, reading a single char (`"3"` → 51 ASCII). Without this override, `info.version >= 4` silently fires on all v3 YAML files.
- `kEncodingVersion` bumped to 4. Version check keeps accepting v2 and v3.

## Benchmarks

Measured on Intel i7-13700H vs baseline at `5605b61` (raw artifacts in repo root `baseline_results.md` / `feature_results.md`).

### pcd_benchmark (`lidar.pcd`, 3 reps, median)
| Metric | Baseline | Feature | Delta |
|---|---:|---:|---:|
| Lossy+ZSTD encode | 1.629 ms | 1.663 ms | within noise |
| Lossy+ZSTD ratio | 12.44 % | 12.44 % | identical |
| Lossy+ZSTD decode | 2.138 ms | 2.155 ms | within noise |
| Lossless+ZSTD ratio (v4) | — | 36.28 % | = v3 forced baseline |
| Lossless+ZSTD ratio (v3 forced) | — | 36.28 % | narrowing parity proved |

### Real rosbags (ZSTD, resolution 0.001)
| Bag | Baseline | Feature |
|---|---:|---:|
| bount (1000 msgs) | 0.585 | **0.316** |
| north1 (1000 msgs) | 0.569 | **0.300** |
| dexory (457 msgs) | 0.170 | 0.170 |

## Backward compatibility matrix

| Writer | Reader | Result | Coverage |
|---|---|---|---|
| v2 (legacy) | feature | ✅ via XOR + byte-terminated chunks | pre-existing v2 tests |
| v3 (`main`) | feature | ✅ via XOR + point-counted chunks | new `DecodeV3_FromLegacyEncoder` |
| feature (v4) | feature | ✅ Gorilla for FLOAT64 lossless | existing + new Gorilla tests |
| feature (v4) | v3 `main` | ❌ old readers reject v4 magic (intentional) | release-notes item |

## Test plan

- [x] `ctest` green (17/17) on Release with `-DBUILD_TESTING=ON`
- [x] `pcd_benchmark` reproduced against the same `lidar.pcd` baseline
- [x] `cloudini_rosbag_converter -c -s` reproduced on bount, north1, dexory
- [x] `DecodeV3_FromLegacyEncoder` — multi-chunk v3 round-trip with FLOAT64 lossless
- [x] `Gorilla_DoesNotActivateForV3` — v3 vs v4 byte-stream divergence asserted
- [ ] CI (ubuntu-build + ros-humble workflows) to run on push
- [ ] Optional: add a checked-in pre-v4 `.bin` fixture for an even stronger compat guard (out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)