### PR TITLE
fix(field_encoder): replace __builtin_expect with C++20 [[likely]]/[[unlikely]] for MSVC

### DIFF
--- a/cloudini_lib/src/field_encoder.cpp
+++ b/cloudini_lib/src/field_encoder.cpp
@@ -59,7 +59,7 @@ size_t FieldEncoderFloatN_Lossy::encode(const ConstBufferView& point_view, Buffe
   const int nan_bits = _mm_movemask_ps(nan_mask);
 
   // Early path for no NaNs (most common case)
-  if (__builtin_expect(nan_bits == 0, 1)) {
+  if (nan_bits == 0) [[likely]] {
     ptr_out += encodeVarint64(delta[0], ptr_out);
     ptr_out += encodeVarint64(delta[1], ptr_out);
     if (fields_count_ > 2) {
@@ -76,7 +76,7 @@ size_t FieldEncoderFloatN_Lossy::encode(const ConstBufferView& point_view, Buffe
 
   // Fallback path (with NaNs or no SIMD)
   for (size_t i = 0; i < fields_count_; ++i) {
-    if (__builtin_expect(std::isnan(vect_real[i]), 0)) {
+    if (std::isnan(vect_real[i])) [[unlikely]] {
       *ptr_out = 0;
       prev_vect_[i] = 0;
       ptr_out++;


### PR DESCRIPTION
## What

Replace `__builtin_expect` with the C++20 `[[likely]]`/`[[unlikely]]` attributes in `FieldEncoderFloatN_Lossy::encode` (`cloudini_lib/src/field_encoder.cpp`).

## Why

`__builtin_expect` is a GCC/Clang builtin; MSVC doesn't provide it. The hint in the **always-compiled** NaN fallback path breaks every MSVC build (the one in the SIMD fast path additionally breaks under `/arch:AVX`). This is the only blocker preventing `cloudini_lib` from compiling under MSVC — the rest of the library is already portable: `intrinsics.hpp` falls back to scalar when `__SSE__`/`__AVX__` aren't defined, and the contrib headers (`unordered_dense.h`, `nanocdr.hpp`, `span.hpp`) are MSVC-safe.

Since cloudini already requires C++20 (`check_min_cppstd(20)`), `[[likely]]`/`[[unlikely]]` is an equivalent, fully portable replacement with **no behavior change** on GCC/Clang.

## Testing

- ✅ `cloudini_lib` rebuilds clean on GCC 13 (Linux) — no regression.
- ⏳ MSVC verification pending a Conan package build; this change unblocks it (the recipe's `is_msvc` `ConanInvalidConfiguration` gate is being removed separately).

## Context

Surfaced while consuming cloudini from PlotJuggler 4, whose Windows CI failed at `conan install` on cloudini's MSVC rejection. This is the upstream code fix that makes MSVC support real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)