### PR TITLE
fix(cloudini_ros): bind node to a named lvalue for PointCloudTransport on Rolling

### DIFF
--- a/cloudini_ros/test/test_plugin_publisher.cpp
+++ b/cloudini_ros/test/test_plugin_publisher.cpp
@@ -42,8 +42,11 @@ class CloudiniPluginPublisherTestNode : public rclcpp::Node {
     RCLCPP_INFO(this->get_logger(), "Subscribing to: %s", input_topic.c_str());
     RCLCPP_INFO(this->get_logger(), "Publishing to: %s", output_topic.c_str());
 
-    // Create point_cloud_transport publisher
-    pct_ = std::make_shared<point_cloud_transport::PointCloudTransport>(shared_from_this());
+    // Create point_cloud_transport publisher. PointCloudTransport binds the node by
+    // non-const lvalue ref (rclcpp::NodeInterfaces), so pass a named lvalue — Rolling
+    // dropped the deprecated by-value Node::SharedPtr ctor.
+    std::shared_ptr<rclcpp::Node> node = shared_from_this();
+    pct_ = std::make_shared<point_cloud_transport::PointCloudTransport>(node);
     transport_publisher_ = pct_->advertise(output_topic, 10);
 
     // Create standard ROS2 subscriber

--- a/cloudini_ros/test/test_plugin_subscriber.cpp
+++ b/cloudini_ros/test/test_plugin_subscriber.cpp
@@ -48,7 +48,10 @@ class CloudiniPluginTestNode : public rclcpp::Node {
     RCLCPP_INFO(this->get_logger(), "Subscribing to topic: %s", topic.c_str());
     RCLCPP_INFO(this->get_logger(), "Using transport: %s", transport.c_str());
 
-    pct_ = std::make_shared<point_cloud_transport::PointCloudTransport>(shared_from_this());
+    // PointCloudTransport binds the node by non-const lvalue ref (rclcpp::NodeInterfaces),
+    // so pass a named lvalue — Rolling dropped the deprecated by-value Node::SharedPtr ctor.
+    std::shared_ptr<rclcpp::Node> node = shared_from_this();
+    pct_ = std::make_shared<point_cloud_transport::PointCloudTransport>(node);
 
     // Create transport hints to specify which compression to use
     auto transport_hint = std::make_shared<point_cloud_transport::TransportHints>(transport);


### PR DESCRIPTION
## Problem

The ROS 2 buildfarm devel job fails to build `cloudini_ros` on Rolling/Resolute (GCC 15):
[Rdev__cloudini__ubuntu_resolute_amd64 #6](https://build.ros2.org/job/Rdev__cloudini__ubuntu_resolute_amd64/6/consoleText)

```
test/test_plugin_subscriber.cpp:51 …
error: no matching function for call to
  'construct_at(point_cloud_transport::PointCloudTransport*&, std::shared_ptr<rclcpp::Node>)'
error: cannot bind non-const lvalue reference of type 'std::shared_ptr<rclcpp::Node>&' to an rvalue
note: NodeInterfaces(NodeT & node)
```

## Root cause

`point_cloud_transport` **removed** its deprecated by-value constructor `PointCloudTransport(rclcpp::Node::SharedPtr)` on Rolling, leaving only `PointCloudTransport(rclcpp::node_interfaces::NodeInterfaces<…>)`. Building a `NodeInterfaces` from a node goes through `NodeInterfaces(NodeT& node)` — a **non-const lvalue reference** — so the temporary returned by `shared_from_this()` can no longer bind.

## Fix

Bind `shared_from_this()` to a named lvalue before constructing `PointCloudTransport`, in both plugin tests (`test_plugin_publisher.cpp`, `test_plugin_subscriber.cpp`). Distro-safe: older distros still have the by-value ctor (lvalue binds it); Rolling/Resolute use the `NodeInterfaces` ctor (lvalue binds `NodeInterfaces(NodeT&)`). No `-Werror` in `cloudini_ros`, so the deprecation on intermediate distros is non-fatal.

The `ros-rolling` workflow in this repo builds+tests `cloudini_ros` on Rolling, so CI here reproduces and verifies the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)