### PR TITLE
Release Foxglove extension as installable .foxe again

### DIFF
--- a/.github/workflows/release-appimage.yaml
+++ b/.github/workflows/release-appimage.yaml
@@ -154,20 +154,15 @@ jobs:
         working-directory: cloudini_foxglove
         run: npm ci
 
-      - name: Build Foxglove extension
+      - name: Package Foxglove extension (.foxe)
         working-directory: cloudini_foxglove
-        run: npm run build
-
-      - name: Package Foxglove extension
-        run: |
-          cd cloudini_foxglove/dist
-          zip -r ../../cloudini-foxglove-${{ steps.get_version.outputs.VERSION }}.zip .
+        run: npm run package
 
       - name: Upload Foxglove artifact
         uses: actions/upload-artifact@v7
         with:
           name: foxglove-artifact
-          path: cloudini-foxglove-*.zip
+          path: cloudini_foxglove/release/*.foxe
 
   create-release:
     needs: [build-appimage, build-wasm, build-foxglove]
@@ -194,6 +189,6 @@ jobs:
           files: |
             appimage-artifact/cloudini_rosbag_converter-*.AppImage
             wasm-artifact/cloudini-wasm-*.zip
-            foxglove-artifact/cloudini-foxglove-*.zip
+            foxglove-artifact/*.foxe
           draft: false
           prerelease: false

--- a/cloudini_foxglove/src/PointCloudConverter.tsx
+++ b/cloudini_foxglove/src/PointCloudConverter.tsx
@@ -33,7 +33,7 @@ export const convertPointCloudWasm = (cloud: CompressedPointCloud): PointCloud =
     point_step: cloud.point_step,
     row_step: cloud.point_step * cloud.width,
     is_dense: cloud.is_dense,
-    data: new Uint8Array(),
+    data: new Uint8Array(0),
   };
 
   // Nothing to do, the point cloud is empty

--- a/cloudini_foxglove/tsconfig.json
+++ b/cloudini_foxglove/tsconfig.json
@@ -28,6 +28,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "module": "esnext",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0"
   }
 }


### PR DESCRIPTION
Hi Davide,

I just noticed that the .foxe has not been built properly for a while now. Cursor promises this is a fix, so I thought I would run this by you in case this was not a planned depreciation.

The release workflow's build-foxglove job had been zipping the raw dist/ folder into cloudini-foxglove-<version>.zip, which is not an installable Foxglove extension. Use the existing `npm run package` script so CI emits a proper .foxe (via foxglove-extension package) and attach that to releases.

Also fix the foxglove extension build, which was broken by the typescript 6.0.3 bump: silence the now-fatal moduleResolution deprecation and give new Uint8Array an explicit length argument.