### PR TITLE
Optional log of compression stats

### DIFF
--- a/cloudini_ros/src/topic_converter.cpp
+++ b/cloudini_ros/src/topic_converter.cpp
@@ -107,6 +107,7 @@ CloudiniPointcloudConverter::CloudiniPointcloudConverter(const rclcpp::NodeOptio
   this->declare_parameter<std::string>("topic_input", "/points");
   this->declare_parameter<std::string>("topic_output", "");
   this->declare_parameter<double>("resolution", 0.001);
+  this->declare_parameter<bool>("log_compression_stats", true);
 
   // read parameters
   compressing_ = this->get_parameter("compressing").as_bool();
@@ -177,6 +178,10 @@ void CloudiniPointcloudConverter::callback(std::shared_ptr<rclcpp::SerializedMes
   output_message_.get_rcl_serialized_message().buffer_length = output_raw_message_.size();
   output_message_.get_rcl_serialized_message().buffer = output_raw_message_.data();
   point_cloud_publisher_->publish(output_message_);
+
+  if (!this->get_parameter("log_compression_stats").as_bool()) {
+    return;
+  }
 
   tot_original_size += input_msg.buffer_length;
   tot_compressed_size += output_raw_message_.size();


### PR DESCRIPTION
Make the log with compression stats optional so this node is pretty much usable directly in deployments.

I find myself putting this node as a composable in lidar pipelines a lot, simply to efficiently record pointclouds in rosbags.
However, I don't like the logging of the compression stats by default so I propose to make this a live toggle.