### PR TITLE
Stamp foxe version from tag

### DIFF
--- a/.github/workflows/release-appimage.yaml
+++ b/.github/workflows/release-appimage.yaml
@@ -154,6 +154,14 @@ jobs:
         working-directory: cloudini_foxglove
         run: npm ci
 
+      # Sync the extension version to the release tag so the packaged .foxe
+      # filename and its embedded package.json version always match the tag.
+      # Skipped on manual (workflow_dispatch) runs where VERSION is "latest".
+      - name: Set extension version from tag
+        if: github.event_name == 'push'
+        working-directory: cloudini_foxglove
+        run: npm version "${{ steps.get_version.outputs.VERSION }}" --no-git-tag-version --allow-same-version
+
       - name: Package Foxglove extension (.foxe)
         working-directory: cloudini_foxglove
         run: npm run package

--- a/.github/workflows/release-appimage.yaml
+++ b/.github/workflows/release-appimage.yaml
@@ -154,9 +154,7 @@ jobs:
         working-directory: cloudini_foxglove
         run: npm ci
 
-      # Sync the extension version to the release tag so the packaged .foxe
-      # filename and its embedded package.json version always match the tag.
-      # Skipped on manual (workflow_dispatch) runs where VERSION is "latest".
+      # Set the extension version from the tag
       - name: Set extension version from tag
         if: github.event_name == 'push'
         working-directory: cloudini_foxglove


### PR DESCRIPTION
Hi Davide,

With the latest release I noticed the foxe version was not bumped - this is because it was hardcoded before. I propose we add support for writing it from tag to skip manually changing the version going forward.